### PR TITLE
fix: [CHK-2981] customize span by adding patch trigger kind

### DIFF
--- a/src/main/kotlin/it/pagopa/wallet/eventdispatcher/queues/WalletExpirationQueueConsumer.kt
+++ b/src/main/kotlin/it/pagopa/wallet/eventdispatcher/queues/WalletExpirationQueueConsumer.kt
@@ -89,18 +89,26 @@ class WalletExpirationQueueConsumer(
                         )
                     }
                 }
-                .doOnError(WalletPatchStatusError::class.java) {
+                .doOnError {
                     tracing.customizeSpan<Unit>(Mono.error(it)) {
                         setAttribute(
                             TracingKeys.PATCH_STATE_OUTCOME_KEY,
                             TracingKeys.WalletPatchOutcome.FAIL.name
                         )
-                        setAttribute(
-                            TracingKeys.PATCH_STATE_OUTCOME_STATUS_CODE_KEY,
-                            it.getHttpResponseCode()
-                                .map { code -> code.value().toString() }
-                                .orElse("")
-                        )
+                        when (it) {
+                            is WalletPatchStatusError ->
+                                setAttribute(
+                                    TracingKeys.PATCH_STATE_OUTCOME_FAIL_STATUS_CODE_KEY,
+                                    it.getHttpResponseCode()
+                                        .map { code -> code.value().toString() }
+                                        .orElse("")
+                                )
+                            else ->
+                                setAttribute(
+                                    TracingKeys.PATCH_STATE_OUTCOME_FAIL_STATUS_CODE_KEY,
+                                    ""
+                                )
+                        }
                     }
                 }
         ) {

--- a/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/Tracing.kt
+++ b/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/Tracing.kt
@@ -30,6 +30,14 @@ class Tracing(private val openTelemetry: OpenTelemetry, private val tracer: Trac
         const val BAGGAGE: String = "baggage"
     }
 
+    fun <T> customizeSpan(mono: Mono<T>, f: Span.() -> Unit): Mono<T> {
+        return Mono.using(
+            { Span.fromContext(Context.current()) },
+            { span -> f(span).let { mono } },
+            {}
+        )
+    }
+
     fun <T> traceMonoWithRemoteSpan(
         spanName: String,
         tracingInfo: TracingInfo?,

--- a/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/Tracing.kt
+++ b/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/Tracing.kt
@@ -30,7 +30,7 @@ class Tracing(private val openTelemetry: OpenTelemetry, private val tracer: Trac
         const val BAGGAGE: String = "baggage"
     }
 
-    fun <T> customizeSpan(mono: Mono<T>, f: Span.() -> Unit): Mono<T> {
+    fun <T> customizeSpan(mono: Mono<out T>, f: Span.() -> Unit): Mono<T> {
         return Mono.using(
             { Span.fromContext(Context.current()) },
             { span -> f(span).let { mono } },

--- a/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/TracingKeys.kt
+++ b/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/TracingKeys.kt
@@ -7,7 +7,7 @@ object TracingKeys {
     val PATCH_STATE_WALLET_ID_KEY = AttributeKey.stringKey("wallet.patch.state.walletId")
     val PATCH_STATE_TRIGGER_KEY = AttributeKey.stringKey("wallet.patch.state.trigger")
     val PATCH_STATE_OUTCOME_KEY = AttributeKey.stringKey("wallet.patch.state.outcome")
-    val PATCH_STATE_OUTCOME_STATUS_CODE_KEY =
+    val PATCH_STATE_OUTCOME_FAIL_STATUS_CODE_KEY =
         AttributeKey.stringKey("wallet.patch.state.outcome.fail.code")
 
     enum class WalletPatchTriggerKind {

--- a/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/TracingKeys.kt
+++ b/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/TracingKeys.kt
@@ -4,9 +4,18 @@ import io.opentelemetry.api.common.AttributeKey
 
 object TracingKeys {
 
+    val PATCH_STATE_WALLET_ID_KEY = AttributeKey.stringKey("wallet.patch.state.walletId")
     val PATCH_STATE_TRIGGER_KEY = AttributeKey.stringKey("wallet.patch.state.trigger")
+    val PATCH_STATE_OUTCOME_KEY = AttributeKey.stringKey("wallet.patch.state.outcome")
+    val PATCH_STATE_OUTCOME_STATUS_CODE_KEY =
+        AttributeKey.stringKey("wallet.patch.state.outcome.fail.code")
 
     enum class WalletPatchTriggerKind {
         WALLET_EXPIRE
+    }
+
+    enum class WalletPatchOutcome {
+        OK,
+        FAIL,
     }
 }

--- a/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/TracingKeys.kt
+++ b/src/main/kotlin/it/pagopa/wallet/eventdispatcher/utils/TracingKeys.kt
@@ -1,0 +1,12 @@
+package it.pagopa.wallet.eventdispatcher.utils
+
+import io.opentelemetry.api.common.AttributeKey
+
+object TracingKeys {
+
+    val PATCH_STATE_TRIGGER_KEY = AttributeKey.stringKey("wallet.patch.state.trigger")
+
+    enum class WalletPatchTriggerKind {
+        WALLET_EXPIRE
+    }
+}

--- a/src/test/kotlin/it/pagopa/wallet/eventdispatcher/queues/WalletExpirationQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/eventdispatcher/queues/WalletExpirationQueueConsumerTest.kt
@@ -80,7 +80,7 @@ class WalletExpirationQueueConsumerTest {
     }
 
     @Test
-    fun `Should propagate error patching wallet status to ERROT`() {
+    fun `Should propagate error patching wallet status to ERROR`() {
         val walletId = UUID.randomUUID()
         val creationDate = "2024-06-14T15:04:56.908428Z"
         val walletCreationDate = OffsetDateTime.parse(creationDate)

--- a/src/test/kotlin/it/pagopa/wallet/eventdispatcher/queues/WalletExpirationQueueConsumerTest.kt
+++ b/src/test/kotlin/it/pagopa/wallet/eventdispatcher/queues/WalletExpirationQueueConsumerTest.kt
@@ -2,12 +2,18 @@ package it.pagopa.wallet.eventdispatcher.queues
 
 import com.azure.spring.messaging.checkpoint.Checkpointer
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.Span
+import it.pagopa.generated.wallets.model.WalletStatus
 import it.pagopa.generated.wallets.model.WalletStatusErrorPatchRequest
 import it.pagopa.generated.wallets.model.WalletStatusErrorPatchRequestDetails
 import it.pagopa.wallet.eventdispatcher.api.WalletsApi
 import it.pagopa.wallet.eventdispatcher.common.queue.QueueEvent
 import it.pagopa.wallet.eventdispatcher.configuration.SerializationConfiguration
 import it.pagopa.wallet.eventdispatcher.domain.WalletCreatedEvent
+import it.pagopa.wallet.eventdispatcher.exceptions.WalletPatchStatusError
+import it.pagopa.wallet.eventdispatcher.utils.Tracing
+import it.pagopa.wallet.eventdispatcher.utils.TracingKeys
 import it.pagopa.wallet.eventdispatcher.utils.TracingMock
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
@@ -19,6 +25,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.*
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 
@@ -30,12 +38,13 @@ class WalletExpirationQueueConsumerTest {
         serializationConfiguration.objectMapperBuilder().build()
     private val azureJsonSerializer = serializationConfiguration.azureJsonSerializer(objectMapper)
     private val walletsApi: WalletsApi = mock()
+    private val tracing: Tracing = TracingMock.mock()
 
     private val walletExpirationQueueConsumer =
         WalletExpirationQueueConsumer(
             azureJsonSerializer = azureJsonSerializer,
             walletsApi = walletsApi,
-            tracing = TracingMock.mock()
+            tracing = tracing
         )
 
     @Test
@@ -51,9 +60,6 @@ class WalletExpirationQueueConsumerTest {
                     creationDate = walletCreationDate
                 )
             )
-        val baos = ByteArrayOutputStream()
-        azureJsonSerializer.createInstance().serialize(baos, walletCreatedEvent)
-        val payload = baos.toByteArray()
         given(checkPointer.success()).willReturn(Mono.empty())
         given(walletsApi.updateWalletStatus(any(), any())).willReturn(mono {})
         val expectedPatchRequest =
@@ -65,7 +71,7 @@ class WalletExpirationQueueConsumerTest {
                 )
         StepVerifier.create(
                 walletExpirationQueueConsumer.messageReceiver(
-                    payload = payload,
+                    payload = serializeEvent(walletCreatedEvent),
                     checkPointer = checkPointer
                 )
             )
@@ -77,6 +83,20 @@ class WalletExpirationQueueConsumerTest {
                 walletId = walletId,
                 walletStatusPatchRequest = expectedPatchRequest
             )
+
+        val span =
+            argumentCaptor<Span.() -> Unit> {
+                    verify(tracing, times(2)).customizeSpan(any<Mono<*>>(), capture())
+                }
+                .reduceSpan()
+
+        verifySpanAttributes(
+            span,
+            TracingKeys.PATCH_STATE_WALLET_ID_KEY to walletId.toString(),
+            TracingKeys.PATCH_STATE_TRIGGER_KEY to
+                TracingKeys.WalletPatchTriggerKind.WALLET_EXPIRE.name,
+            TracingKeys.PATCH_STATE_OUTCOME_KEY to TracingKeys.WalletPatchOutcome.OK.name
+        )
     }
 
     @Test
@@ -92,9 +112,6 @@ class WalletExpirationQueueConsumerTest {
                     creationDate = walletCreationDate
                 )
             )
-        val baos = ByteArrayOutputStream()
-        azureJsonSerializer.createInstance().serialize(baos, walletCreatedEvent)
-        val payload = baos.toByteArray()
         given(checkPointer.success()).willReturn(Mono.empty())
         given(walletsApi.updateWalletStatus(any(), any()))
             .willReturn(Mono.error(RuntimeException("Error patching wallet")))
@@ -107,7 +124,7 @@ class WalletExpirationQueueConsumerTest {
                 )
         StepVerifier.create(
                 walletExpirationQueueConsumer.messageReceiver(
-                    payload = payload,
+                    payload = serializeEvent(walletCreatedEvent),
                     checkPointer = checkPointer
                 )
             )
@@ -122,6 +139,83 @@ class WalletExpirationQueueConsumerTest {
                 walletId = walletId,
                 walletStatusPatchRequest = expectedPatchRequest
             )
+
+        val span =
+            argumentCaptor<Span.() -> Unit> {
+                    verify(tracing, times(2)).customizeSpan(any<Mono<*>>(), capture())
+                }
+                .reduceSpan()
+
+        verifySpanAttributes(
+            span,
+            TracingKeys.PATCH_STATE_WALLET_ID_KEY to walletId.toString(),
+            TracingKeys.PATCH_STATE_TRIGGER_KEY to
+                TracingKeys.WalletPatchTriggerKind.WALLET_EXPIRE.name,
+            TracingKeys.PATCH_STATE_OUTCOME_KEY to TracingKeys.WalletPatchOutcome.FAIL.name,
+            TracingKeys.PATCH_STATE_OUTCOME_FAIL_STATUS_CODE_KEY to ""
+        )
+    }
+
+    @Test
+    fun `Should propagate error patching wallet status to ERROR with status code`() {
+        val walletId = UUID.randomUUID()
+        val creationDate = "2024-06-14T15:04:56.908428Z"
+        val walletCreationDate = OffsetDateTime.parse(creationDate)
+        val walletCreatedEvent =
+            QueueEvent(
+                WalletCreatedEvent(
+                    walletId = walletId.toString(),
+                    eventId = UUID.randomUUID().toString(),
+                    creationDate = walletCreationDate
+                )
+            )
+        given(checkPointer.success()).willReturn(Mono.empty())
+        given(walletsApi.updateWalletStatus(any(), any()))
+            .willReturn(
+                Mono.error(
+                    WalletPatchStatusError(
+                        walletId,
+                        WalletStatus.ERROR.name,
+                        WebClientResponseException(404, "not found", HttpHeaders(), null, null)
+                    )
+                )
+            )
+        val expectedPatchRequest =
+            WalletStatusErrorPatchRequest()
+                .status("ERROR")
+                .details(
+                    WalletStatusErrorPatchRequestDetails()
+                        .reason("Wallet expired. Creation date: $creationDate")
+                )
+        StepVerifier.create(
+                walletExpirationQueueConsumer.messageReceiver(
+                    payload = serializeEvent(walletCreatedEvent),
+                    checkPointer = checkPointer
+                )
+            )
+            .expectError()
+            .verify()
+        verify(checkPointer, times(1)).success()
+        verify(walletsApi, times(1))
+            .updateWalletStatus(
+                walletId = walletId,
+                walletStatusPatchRequest = expectedPatchRequest
+            )
+
+        val span =
+            argumentCaptor<Span.() -> Unit> {
+                    verify(tracing, times(2)).customizeSpan(any<Mono<*>>(), capture())
+                }
+                .reduceSpan()
+
+        verifySpanAttributes(
+            span,
+            TracingKeys.PATCH_STATE_WALLET_ID_KEY to walletId.toString(),
+            TracingKeys.PATCH_STATE_TRIGGER_KEY to
+                TracingKeys.WalletPatchTriggerKind.WALLET_EXPIRE.name,
+            TracingKeys.PATCH_STATE_OUTCOME_KEY to TracingKeys.WalletPatchOutcome.FAIL.name,
+            TracingKeys.PATCH_STATE_OUTCOME_FAIL_STATUS_CODE_KEY to "404"
+        )
     }
 
     @ParameterizedTest
@@ -157,5 +251,25 @@ class WalletExpirationQueueConsumerTest {
             .expectError()
             .verify()
         verify(checkPointer, times(1)).success()
+    }
+
+    private fun <T> serializeEvent(event: T): ByteArray {
+        val baos = ByteArrayOutputStream()
+        azureJsonSerializer.createInstance().serialize(baos, event)
+        return baos.toByteArray()
+    }
+
+    private fun KArgumentCaptor<Span.() -> Unit>.reduceSpan(): Span {
+        return allValues.fold(mock<Span>()) { span, it ->
+            it.invoke(span)
+            span
+        }
+    }
+
+    private fun verifySpanAttributes(
+        span: Span,
+        vararg attributes: Pair<AttributeKey<String>, String>,
+    ) {
+        attributes.forEach { (t, u) -> verify(span, times(1)).setAttribute(eq(t), eq(u)) }
     }
 }

--- a/src/test/kotlin/it/pagopa/wallet/eventdispatcher/utils/TracingMock.kt
+++ b/src/test/kotlin/it/pagopa/wallet/eventdispatcher/utils/TracingMock.kt
@@ -20,6 +20,9 @@ object TracingMock {
             }
             .willAnswer { it.getArgument<() -> Mono<*>>(2).invoke() }
 
+        given { mockedTracingUtils.customizeSpan(any<Mono<*>>(), any()) }
+            .willAnswer { it.getArgument<Mono<*>>(0) }
+
         return mockedTracingUtils
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR allows to trace the wallet state patch performed by wallet-event-dispatcher. We can use patch state for different purposes, for example when a Wallet Expire the state is patched to ERROR. The changes proposed allows to trace on Otel consumer span the purpose of wallet state patch and the outcome.

#### List of Changes

- enriched consumer span with specific attribute keys

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
In DEV
<img width="991" alt="Screenshot 2024-07-15 alle 15 34 22" src="https://github.com/user-attachments/assets/90cbc762-0605-47b3-8815-399a2c0911e1">
<img width="1459" alt="Screenshot 2024-07-15 alle 15 34 30" src="https://github.com/user-attachments/assets/ad266806-19e4-4e84-bd01-6859bf9159a2">


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.