### PR TITLE
feat: update helm values to version 7 to use workload identity

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: microservice-chart
+  repository: https://pagopa.github.io/aks-microservice-chart-blueprint
+  version: 7.3.1
+digest: sha256:f7a6ce88959f9eddc5929c3a4506fce505fd2f0bc81bedd11f1d79b3c5ac7a17
+generated: "2025-02-21T09:54:20.764661+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.11.0
 appVersion: 0.10.0
 dependencies:
   - name: microservice-chart
-    version: 2.8.0
+    version: 7.3.1
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/pay-wallet-values-dev.yaml
+++ b/helm/pay-wallet-values-dev.yaml
@@ -2,6 +2,22 @@ microservice-chart:
   namespace: "pay-wallet"
   nameOverride: ""
   fullnameOverride: "pagopa-pay-wallet-event-dispatcher-microservice"
+  canaryDelivery:
+    create: false
+    ingress:
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopaditncoreacr.azurecr.io/pagopapaymentwalleteventdispatcherservice
+      tag: "latest"
+    envConfig:
+      OTEL_SERVICE_NAME: "pagopa-payment-wallet-event-dispatcher-service-blue"
+      OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-payment-wallet-event-dispatcher-service-blue,deployment.environment=dev"
+    envSecret: { }
   image:
     repository: pagopaditncoreacr.azurecr.io/pagopapaymentwalleteventdispatcherservice
     tag: "0.10.0"
@@ -34,9 +50,9 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
-  podAnnotations: {}
+    annotations: { }
+    name: "pay-wallet-workload-identity"
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -103,7 +119,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-d-pay-wallet-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
+  nodeSelector: { }
   tolerations:
     - effect: "NoSchedule"
       key: "paymentWalletOnly"
@@ -124,6 +140,8 @@ microservice-chart:
           podAffinityTerm:
             labelSelector:
               matchLabels:
-                aadpodidbinding: pay-wallet-pod-identity
-            namespaces: ["pay-wallet"]
+                app.kubernetes.io/instance: pagopapaymentwalleteventdispatcherservice
+            namespaces: [ "pay-wallet" ]
             topologyKey: topology.kubernetes.io/zone
+  azure:
+    workloadIdentityClientId: 8cad3639-cc88-4bff-85fe-5b1ddb2d449e

--- a/helm/pay-wallet-values-prod.yaml
+++ b/helm/pay-wallet-values-prod.yaml
@@ -2,6 +2,22 @@ microservice-chart:
   namespace: "pay-wallet"
   nameOverride: ""
   fullnameOverride: "pagopa-pay-wallet-event-dispatcher-microservice"
+  canaryDelivery:
+    create: false
+    ingress:
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopapitncoreacr.azurecr.io/pagopapaymentwalleteventdispatcherservice
+      tag: "latest"
+    envConfig:
+      OTEL_SERVICE_NAME: "pagopa-payment-wallet-event-dispatcher-service-blue"
+      OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-payment-wallet-event-dispatcher-service-blue,deployment.environment=prod"
+    envSecret: { }
   image:
     repository: pagopapitncoreacr.azurecr.io/pagopapaymentwalleteventdispatcherservice
     tag: "0.10.0"
@@ -35,9 +51,9 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
-  podAnnotations: {}
+    annotations: { }
+    name: "pay-wallet-workload-identity"
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -115,23 +131,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-p-pay-wallet-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
-  canaryDelivery:
-    create: false
-    ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopapitncoreacr.azurecr.io/pagopawalleteventdispatcher
-        tag: "latest"
-        pullPolicy: Always
-      envConfig: {}
-      envSecret: {}
+  nodeSelector: { }
   tolerations:
     - effect: "NoSchedule"
       key: "paymentWalletOnly"
@@ -152,6 +152,8 @@ microservice-chart:
           podAffinityTerm:
             labelSelector:
               matchLabels:
-                aadpodidbinding: pay-wallet-pod-identity
-            namespaces: ["pay-wallet"]
+                app.kubernetes.io/instance: pagopapaymentwalleteventdispatcherservice
+            namespaces: [ "pay-wallet" ]
             topologyKey: topology.kubernetes.io/zone
+  azure:
+    workloadIdentityClientId: 48a74dad-26f3-4916-ba45-ddda27d950b1

--- a/helm/pay-wallet-values-uat.yaml
+++ b/helm/pay-wallet-values-uat.yaml
@@ -2,6 +2,22 @@ microservice-chart:
   namespace: "pay-wallet"
   nameOverride: ""
   fullnameOverride: "pagopa-pay-wallet-event-dispatcher-microservice"
+  canaryDelivery:
+    create: false
+    ingress:
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopauitncoreacr.azurecr.io/pagopapaymentwalleteventdispatcherservice
+      tag: "latest"
+    envConfig:
+      OTEL_SERVICE_NAME: "pagopa-payment-wallet-event-dispatcher-service-blue"
+      OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-payment-wallet-event-dispatcher-service-blue,deployment.environment=uat"
+    envSecret: { }
   image:
     repository: pagopauitncoreacr.azurecr.io/pagopapaymentwalleteventdispatcherservice
     tag: "0.10.0"
@@ -34,9 +50,9 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
-  podAnnotations: {}
+    annotations: { }
+    name: "pay-wallet-workload-identity"
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -103,27 +119,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-u-pay-wallet-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
-  canaryDelivery:
-    create: false
-    ingress:
-      create: false
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopauitncoreacr.azurecr.io/pagopapaymentwalleteventdispatcherservice
-        tag: "latest"
-        pullPolicy: Always
-      envConfig:
-        OTEL_SERVICE_NAME: "pagopa-payment-wallet-event-dispatcher-service-blue"
-        WALLET_USAGE_QUEUE_NAME: "pagopa-u-itn-pay-wallet-usage-update-queue-b"
-        WALLET_EXPIRATION_QUEUE_NAME: "pagopa-u-itn-pay-wallet-expiration-queue-b"
-        WALLET_SERVICE_URI: "http://beta-pagopa-pay-wallet-microservice.pay-wallet.svc:8080"
-      envSecret: {}
+  nodeSelector: { }
   tolerations:
     - effect: "NoSchedule"
       key: "paymentWalletOnly"
@@ -144,6 +140,8 @@ microservice-chart:
           podAffinityTerm:
             labelSelector:
               matchLabels:
-                aadpodidbinding: pay-wallet-pod-identity
-            namespaces: ["pay-wallet"]
+                app.kubernetes.io/instance: pagopapaymentwalleteventdispatcherservice
+            namespaces: [ "pay-wallet" ]
             topologyKey: topology.kubernetes.io/zone
+  azure:
+    workloadIdentityClientId: 928bc159-85e9-4f09-ba08-1e71851166f1


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Upgrade to helm chart 7 performing the following modifications:
- chat version update from 2.8.0 to 7.3.1
- canaryDelivery parameter update to the new template (adding canary section)
- add workload identity refs for each environment specifying the azure workload identity client id and service account name for each env
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modification are needed in order to make payment wallet use workload identities instead of deprecated pod identity
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Deploy in dev env
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
