### PR TITLE
[PIDM-454] fix: expanded prod rollback trigger conditions

### DIFF
--- a/.devops/pay-wallet-deploy-pipelines.yml
+++ b/.devops/pay-wallet-deploy-pipelines.yml
@@ -788,7 +788,7 @@ stages:
     condition: |
       and(
         eq(${{parameters.UAT_PROD_DEPLOY}}, true),
-        eq(dependencies.Scale_Down_Staging_Deployment.result, 'Succeeded'),
+        in(dependencies.Scale_Down_Staging_Deployment.result, 'Succeeded', 'SucceededWithIssues', 'Failed', 'Skipped', 'Canceled'),
         in(dependencies.Release.result, 'Succeeded', 'Skipped')
       )
     variables:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Updated the condition for triggering the production rollback stage in `.devops/deploy-pipelines.yml`.
- Replaced a strict equality check on `Deploy_PROD_Green.result == 'Succeeded'` with a more flexible condition using `in(...)` to allow multiple result states.
<!--- Describe your changes in detail -->

#### Motivation and Context
This change ensures the rollback logic in the production environment is more robust by allowing the rollback stage to proceed not only when the previous job succeeded, but also when it ended with issues, failure, or was skipped or canceled. This adjustment prevents scenarios where a rollback might be incorrectly skipped due to unexpected pipeline result states.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.